### PR TITLE
Ignore pytest timeout threads in lingering

### DIFF
--- a/requirements/test-ci-base.txt
+++ b/requirements/test-ci-base.txt
@@ -1,5 +1,4 @@
 pytest-cov
-pytest-sugar
 pytest-travis-fold
 codecov
 -r extras/redis.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,7 @@
 case>=1.3.1
 pytest~=4.6; python_version < '3.0'
 pytest~=6.0; python_version >= '3.0'
+pytest-timeout~=1.4.2
 boto3>=1.9.178
 python-dateutil<2.8.1,>=2.1; python_version < '3.0'
 moto==1.3.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 testpaths = t/unit/
 python_classes = test_*
 xfail_strict=true
+timeout = 300
 
 [build_sphinx]
 source-dir = docs/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [tool:pytest]
+addopts = --strict-markers
 testpaths = t/unit/
 python_classes = test_*
 xfail_strict=true

--- a/t/unit/conftest.py
+++ b/t/unit/conftest.py
@@ -133,7 +133,11 @@ def AAA_disable_multiprocessing():
 
 
 def alive_threads():
-    return [thread for thread in threading.enumerate() if thread.is_alive()]
+    return [
+        thread
+        for thread in threading.enumerate()
+        if not thread.name.startswith("pytest_timeout ") and thread.is_alive()
+    ]
 
 
 @pytest.fixture(autouse=True)

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -793,7 +793,6 @@ class test_WorkController(ConsumerCase):
         assert worker.autoscaler
 
     @skip.if_win32()
-    @pytest.mark.nothreads_not_lingering
     @mock.sleepdeprived(module=autoscale)
     def test_with_autoscaler_file_descriptor_safety(self):
         # Given: a test celery worker instance with auto scaling
@@ -843,7 +842,6 @@ class test_WorkController(ConsumerCase):
         worker.pool.terminate()
 
     @skip.if_win32()
-    @pytest.mark.nothreads_not_lingering
     @mock.sleepdeprived(module=autoscale)
     def test_with_file_descriptor_safety(self):
         # Given: a test celery worker instance


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
